### PR TITLE
Changed self_signed cert locations and directories to be inside install

### DIFF
--- a/fabric_prometheus/ansible/roles/common/tasks/setup_tasks/self_signed_cert_tasks.yml
+++ b/fabric_prometheus/ansible/roles/common/tasks/setup_tasks/self_signed_cert_tasks.yml
@@ -7,23 +7,17 @@
 
       - name: Create Directories for certs
         file: 
-          path: "{{ self_signed_cert_path }}"
+          path: "{{ self_signed_cert_dir }}"
+          recurse: yes
           state: directory 
           mode: 755
 
       - name: Create Directories for keys
         file: 
-          path: "{{ self_signed_key_path }}"
+          path: "{{ self_signed_key_dir }}"
+          recurse: yes
           state: directory 
           mode: 710
-
-
-
-      # - name: Ensure directory exists for local self-signed TLS certs.
-      #   file:
-      #     path: "{{ self_signed_cert_path }}"
-      #     #path: /etc/test_ssl/{{ hostname }}
-      #     state: directory
 
       - name: Generate an OpenSSL private key.
         openssl_privatekey:
@@ -40,9 +34,6 @@
 
       - name: Generate a Self Signed OpenSSL certificate.
         openssl_certificate:
-          # path: /etc/test_ssl/{{ hostname }}/fullchain.pem
-          # privatekey_path: /etc/test_ssl/{{ hostname }}/privkey.pem
-          # csr_path: /etc/ssl/private/{{ hostname }}.csr
           path: "{{ host_cert }}"
           privatekey_path: "{{ host_key }}"
           csr_path: "{{ host_csr }}"

--- a/fabric_prometheus/ansible/roles/fabric_central/defaults/main.yml
+++ b/fabric_prometheus/ansible/roles/fabric_central/defaults/main.yml
@@ -58,7 +58,7 @@ add_python_docker_sdk: no
 # tls_public_dir: /etc/ssl/certs
 
 # host_csr: "{{ tls_private_dir }}/fab_prom_self_signed_{{ hostname }}.csr"
-# self_signed_cert_path: "{{ tls_public_dir }}/fab_prom_self_signed_{{ hostname }}"
+# self_signed_cert_dir: "{{ tls_public_dir }}/fab_prom_self_signed_{{ hostname }}"
 
 # host_cert: "{{ tls_public_dir }}/fab_prom_self_signed_{{ hostname }}/fullchain.pem"
 # host_key: "{{ tls_private_dir }}/fab_prom_self_signed_{{ hostname }}/privkey.pem"
@@ -72,12 +72,12 @@ add_python_docker_sdk: no
 # -----------------------------------------------
 ## if we need to create our own self signed certs 
 
-#self_signed_cert_path: "{{ base_install_dir }}/ssl"
-#self_signed_key_path: "{{ base_install_dir }}/ssl/private"
+#self_signed_cert_dir: "{{ base_install_dir }}/ssl"
+#self_signed_key_dir: "{{ base_install_dir }}/ssl/private"
 
-#host_csr: "{{ self_signed_cert_path }}/{{ hostname }}.csr"
-#host_cert: "{{ self_signed_cert_path }}/{{ hostname }}_fullchain.pem"
-#host_key: "{{ self_signed_key_path }}/{{ hostname }}_privkey.pem"
+#host_csr: "{{ self_signed_cert_dir }}/{{ hostname }}.csr"
+#host_cert: "{{ self_signed_cert_dir }}/{{ hostname }}_fullchain.pem"
+#host_key: "{{ self_signed_key_dir }}/{{ hostname }}_privkey.pem"
 ## Used to verify 
 #host_interm_cert: "{{ host_cert }}"
 

--- a/fabric_prometheus/ansible/roles/fabric_central/tasks/fabric_central_install_tasks.yml
+++ b/fabric_prometheus/ansible/roles/fabric_central/tasks/fabric_central_install_tasks.yml
@@ -65,7 +65,7 @@
 - name: Self-signed certs.
   include_tasks: setup_tasks/self_signed_cert_tasks.yml
   when:
-    - self_signed_cert_path is defined
+    - self_signed_cert_dir is defined
 
 # need to add uky_incommon_root_intermdiate.pem file to the created intermediate cert!!!!!!TODO!!!!!!!!!!!
 

--- a/fabric_prometheus/ansible/roles/geni/vars/main.yml
+++ b/fabric_prometheus/ansible/roles/geni/vars/main.yml
@@ -43,16 +43,14 @@ prom_group_name: fab-prom
 # Locations for self signed cert creation.
 # If host aleady has certs, then skip the self-signed task and
 #  just use the cert on the host machine.
-host_csr: /etc/ssl/private/{{ hostname }}.csr
-self_signed_cert_path: /etc/test_ssl/{{ hostname }}
+self_signed_cert_dir: "{{ base_install_dir }}/ssl/{{ hostname }}"
+self_signed_key_dir: "{{ base_install_dir }}/ssl/private/{{hostname}}"
 
-# where was this before? still needed?
-self_signed_key_path: /etc/test_ssl/{{hostname}}
+host_csr: "{{ self_signed_cert_dir }}/{{ hostname }}.csr"
+host_cert: "{{ self_signed_cert_dir }}/{{ hostname }}_fullchain.pem"
+host_key: "{{ self_signed_key_dir }}//{{ hostname }}_privkey.pem"
 
-host_cert: /etc/test_ssl/{{ hostname }}/fullchain.pem
-host_key: /etc/test_ssl/{{ hostname }}/privkey.pem
-
-host_interm_cert: /etc/test_ssl/{{ hostname }}/fullchain.pem
+host_interm_cert: "{{ self_signed_cert_dir }}/{{ hostname }}_fullchain.pem"
 
 
 # Prometheus


### PR DESCRIPTION
Self signed certs are only used on geni branch or central if testing on temp node. 
Changed the cert/key dir structure to be inside the install dir to avoid using OS specific directories for certs.