### PR TITLE
Added from rack name to vpn ping alert.

### DIFF
--- a/instrumentize/prometheus/ansible/roles/common/files/alert_rules/vpn_ping_alert_rules.yml
+++ b/instrumentize/prometheus/ansible/roles/common/files/alert_rules/vpn_ping_alert_rules.yml
@@ -15,8 +15,8 @@ groups:
       fabric_system: vpn
       fabric_response: system
     annotations:
-      summary:  "VPN ping to {{ $labels.instance }} failed for 5 minutes."   
-      description:  "{{ $labels.instance }} did not respond to VPN ping for 5 minutes." 
+      summary:  "VPN ping from {{ $labels.rack }} to {{ $labels.instance }} failed for 5 minutes."   
+      description:  "{{ $labels.instance }} did not respond to VPN ping from {{ $labels.rack }} for 5 minutes." 
 
   - alert: VPNPingFailing
     expr: probe_success {job="ping", reason="vpn"} == 0
@@ -26,5 +26,5 @@ groups:
       fabric_system: vpn 
       fabric_repsonse: system
     annotations:
-      summary:  "VPN ping to {{ $labels.instance }} has failed for 15 minutes."   
-      description:  "{{ $labels.instance }} has not responded to VPN ping for more than 15 minutes." 
+      summary:  "VPN ping from {{ $labels.rack }} to {{ $labels.instance }} has failed for 15 minutes."   
+      description:  "{{ $labels.instance }} has not responded to VPN ping from {{ $labels.rack }} for more than 15 minutes." 


### PR DESCRIPTION
# All

Alert names should no longer have spaces in the name.
Updated docker image versions.

Lowered alert temperature for HostPhysicalComponentTooHot alert to 60 C.
Added dataplane link alerts.
Added dataplane isis recording rules.

Prometheus port 9090 moved to operations network.


# Central Metrics

Central now has thanos exporters.
Removed unresponsive thanos stores (ipv6 racks).
Grafana now listens on ipv4 and ipv6.
Added beta portal and beta jupyterhub monitoring.

# Experiment

Initial addition of instrumentizing  user experiment.
