### PR TITLE
Changed setup_docker_dual.. to setup_dcoker_ipvs

### DIFF
--- a/instrumentize/prometheus/ansible/roles/fabric_rack/tasks/fabric_rack_install_tasks.yml
+++ b/instrumentize/prometheus/ansible/roles/fabric_rack/tasks/fabric_rack_install_tasks.yml
@@ -76,7 +76,8 @@
 # OR
 # ipv6 dual network settings
 - name: Setup the docker network to be used by the monitoring containers.
-  include_tasks: setup_tasks/setup_docker_dual_network_tasks.yml
+  # regression error -- include_tasks: setup_tasks/setup_docker_dual_network_tasks.yml
+  include_tasks: setup_tasks/setup_docker_ipv6_network_tasks.yml
   when:
     - network_layer['host']['ipv6'] == "v6"
 


### PR DESCRIPTION
Replaced renamed docker network file. dual to ipv6 to better reflect name.
Also to fix regression error where filename was wrong in rack install tasks file.