### PR TITLE
Switched to using node_exporter collections from prometheus.prometheus

### DIFF
--- a/instrumentize/prometheus/ansible/roles/common/tasks/install_node_exporter_tasks.yml
+++ b/instrumentize/prometheus/ansible/roles/common/tasks/install_node_exporter_tasks.yml
@@ -10,7 +10,7 @@
 
 - name: Install Node Exporter
   include_role: 
-    name: cloudalchemy.node_exporter
+    name: prometheus.prometheus.node_exporter
   
   vars:
     node_exporter_basic_auth_users: "{{ { node_exporter_username : node_exporter_password } }}"

--- a/instrumentize/prometheus/ansible/roles/fabric_rack/templates/Prometheus/base_snmp_targets.yml.j2
+++ b/instrumentize/prometheus/ansible/roles/fabric_rack/templates/Prometheus/base_snmp_targets.yml.j2
@@ -14,17 +14,20 @@
     job: 'data-sw'
     mib_module: 'if_mib'
 
+{% if hostvars[hank_name + '-pdu'] is defined %}
 # PDU
 - targets:
     - "{{hostvars[hank_name + '-pdu'].ansible_host}}"
   labels:
     job: 'pdu'
     mib_module: 'PowerNet'
- 
+{% endif %}
+
+{% if hostvars[hank_name + '-storage'] is defined %}
 # Storage
-- targets: 
+- targets:
     - "{{hostvars[hank_name + '-storage'].ansible_host}}"
   labels:
     job: 'storage'
     mib_module: 'if_mib'
-   
+{% endif %} 


### PR DESCRIPTION
https://github.com/cloudalchemy/ansible-node-exporter has been deprecated and new repo is at https://prometheus-community.github.io/ansible/branch/main/

SNMP targets fail during templating when the hostvar for the device does not exist. Added an if/else .