### PR TITLE
Use the already installed collection for cloudalchemy node_exporter.

### DIFF
--- a/instrumentize/prometheus/ansible/roles/common/tasks/install_node_exporter_tasks.yml
+++ b/instrumentize/prometheus/ansible/roles/common/tasks/install_node_exporter_tasks.yml
@@ -10,7 +10,9 @@
 
 - name: Install Node Exporter
   include_role: 
-    name: prometheus.prometheus.node_exporter
+    #name: prometheus.prometheus.node_exporter
+    #cloudalchemy only works with the os image
+    name: cloudalchemy.node_exporter
   
   vars:
     node_exporter_basic_auth_users: "{{ { node_exporter_username : node_exporter_password } }}"


### PR DESCRIPTION
Fixing node_exporter for os image use.